### PR TITLE
Symlink support; Loockup into the PATH; Ability to hide the terminal name

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+# 4 space indentation
+[*.{py,java,r,R}]
+indent_style = space
+indent_size = 4
+
+# 2 space indentation
+[*.{js,json,y{a,}ml,html,cwl}]
+indent_style = space
+indent_size = 2
+
+[*.{md,Rmd,rst}]
+trim_trailing_whitespace = false
+indent_style = space
+indent_size = 2

--- a/src/nautiterm/open_terminal.py
+++ b/src/nautiterm/open_terminal.py
@@ -18,6 +18,7 @@ import subprocess
 import sys
 import yaml  # for loading configuration
 import gi
+import shutil
 
 gi.require_version('Nautilus', '3.0')
 from gi.repository import Nautilus, GObject, Gio
@@ -75,6 +76,11 @@ class OpenTerminalExtension(Nautilus.MenuProvider, GObject.GObject):
 
         if not terminal:
             terminal = DEFAULT_TERMINAL_EXEC
+
+        terminal = shutil.which(terminal);
+
+        while os.path.islink(terminal):
+            terminal = shutil.which(os.readlink(terminal))
 
         return terminal
 

--- a/src/nautiterm/open_terminal.py
+++ b/src/nautiterm/open_terminal.py
@@ -45,6 +45,7 @@ class Configuration:
             with open(CONFIG_FILE_PATH) as conffile:
                 config = yaml.load(conffile, yaml.SafeLoader)
             terminal = config.get('terminal', None)
+            self.display_name = config.get('display-name', True)
         except yaml.YAMLError:
             print("Nautiterm: invalid configuration file at {path}, falling back" +
                   " to {d}".format(path=CONFIG_FILE_PATH, d=DEFAULT_TERMINAL_EXEC),
@@ -108,15 +109,23 @@ class OpenTerminalExtension(Nautilus.MenuProvider, GObject.GObject):
         if not file.is_directory() or file.get_uri_scheme() != 'file':
             return
 
+        label = 'Open Terminal'
+        if self.configuration.display_name:
+            label += ' (%s)' % self.terminal.name
+
         item = Nautilus.MenuItem(name='NautilusPython::openterminal_file_item',
-                                 label='Open Terminal (%s)' % self.terminal.name,
+                                 label=label,
                                  tip='Open Terminal In %s' % file.get_name())
         item.connect('activate', self.menu_activate_cb, file)
         return item,
 
     def get_background_items(self, window, file):
+        label = 'Open Terminal'
+        if self.configuration.display_name:
+            label += ' (%s)' % self.terminal.name
+
         item = Nautilus.MenuItem(name='NautilusPython::openterminal_file_item2',
-                                 label='Open Terminal (%s)' % self.terminal.name,
+                                 label=label,
                                  tip='Open Terminal In %s' % file.get_name())
         item.connect('activate', self.menu_background_activate_cb, file)
         return item,

--- a/src/nautiterm/open_terminal.py
+++ b/src/nautiterm/open_terminal.py
@@ -21,7 +21,7 @@ import gi
 import shutil
 
 gi.require_version('Nautilus', '3.0')
-from gi.repository import Nautilus, GObject, Gio
+from gi.repository import Nautilus, GObject
 
 PYTHON_MIN_MAJOR_VERSION = 3
 
@@ -76,12 +76,12 @@ class Terminal:
             path = shutil.which(os.readlink(path))
 
         self.path = path
+        self.name = os.path.basename(path)
 
     def open(self, file):
-        gvfs = Gio.Vfs.get_default()
-        open_path = gvfs.get_file_for_uri(file.get_uri()).get_path()
+        open_path = file.get_location().get_path()
 
-        if 'gnome-terminal' in self.path or 'terminator' in self.path:
+        if 'gnome-terminal' in self.name or 'terminator' in self.name:
             subprocess.Popen([self.path, '--working-directory={p}'.format(p=open_path)])
         else:
             os.chdir(open_path)
@@ -109,14 +109,14 @@ class OpenTerminalExtension(Nautilus.MenuProvider, GObject.GObject):
             return
 
         item = Nautilus.MenuItem(name='NautilusPython::openterminal_file_item',
-                                 label='Open Terminal (%s)' % self.terminal.path,
+                                 label='Open Terminal (%s)' % self.terminal.name,
                                  tip='Open Terminal In %s' % file.get_name())
         item.connect('activate', self.menu_activate_cb, file)
         return item,
 
     def get_background_items(self, window, file):
         item = Nautilus.MenuItem(name='NautilusPython::openterminal_file_item2',
-                                 label='Open Terminal (%s)' % self.terminal.path,
+                                 label='Open Terminal (%s)' % self.terminal.name,
                                  tip='Open Terminal In %s' % file.get_name())
         item.connect('activate', self.menu_background_activate_cb, file)
         return item,

--- a/src/nautiterm/open_terminal.py
+++ b/src/nautiterm/open_terminal.py
@@ -12,16 +12,18 @@
 #   URI
 # - Assume Python 3.x
 
+"""Nautilus extension for opening a terminal window at the given/current location."""
+
 import os
 import os.path
 import subprocess
 import sys
+import shutil
 import yaml  # for loading configuration
 import gi
-import shutil
+from gi.repository import Nautilus, GObject
 
 gi.require_version('Nautilus', '3.0')
-from gi.repository import Nautilus, GObject
 
 PYTHON_MIN_MAJOR_VERSION = 3
 
@@ -29,103 +31,132 @@ if sys.version_info[0] < PYTHON_MIN_MAJOR_VERSION:
     raise RuntimeError('Nautiterm requires Python version 3.x or greater')
 
 CONFIG_FILE_NAME = 'nautiterm.yml'
-CONFIG_FILE_DIR = os.environ.get('XDG_CONFIG_HOME',
-                                 os.path.join(os.environ['HOME'], '.config'))
+CONFIG_FILE_DIR = os.environ.get(
+    'XDG_CONFIG_HOME', os.path.join(
+        os.environ['HOME'], '.config'))
 CONFIG_FILE_PATH = os.path.join(CONFIG_FILE_DIR, CONFIG_FILE_NAME)
 DEFAULT_TERMINAL_EXEC = 'gnome-terminal'
 
 print("Starting Nautiterm")
 
+
 class Configuration:
+    """Configuration of module"""
 
     def __init__(self):
         terminal = None
 
         try:
-            with open(CONFIG_FILE_PATH) as conffile:
+            with open(CONFIG_FILE_PATH, encoding="utf-8") as conffile:
                 config = yaml.load(conffile, yaml.SafeLoader)
             terminal = config.get('terminal', None)
-            self.display_name = config.get('display-name', True)
+            self._display_name = config.get('display-name', True)
         except yaml.YAMLError:
-            print("Nautiterm: invalid configuration file at {path}, falling back" +
-                  " to {d}".format(path=CONFIG_FILE_PATH, d=DEFAULT_TERMINAL_EXEC),
-                  file=sys.stderr)
-        except IOError as ioe:
+            print(
+                f'Nautiterm: invalid configuration file at {CONFIG_FILE_PATH}, ' +
+                f'falling back to {DEFAULT_TERMINAL_EXEC}',
+                file=sys.stderr)
+        except IOError:
             # catch-all for permission errors and file not founds to be compatible
-            # with Python 2 which doesn't have FileNotFoundError or PermissionError
+            # with Python 2 which doesn't have FileNotFoundError or
+            # PermissionError
             pass
 
         if not terminal:
             terminal = DEFAULT_TERMINAL_EXEC
 
+        self._terminal = terminal
+
+    def get_terminal(self):
         """
-        Contains the executable name of a terminal emulator to launch based on user
+        Returns the executable name of a terminal emulator to launch based on user
         configuration, or gnome-terminal if nothing else has been specified.
         """
-        self.terminal = terminal
+        return self._terminal
+
+    def is_display_name(self):
+        """Returns flag that indicates is terminal name must be displayed into the context menu."""
+        return self._display_name
+
 
 class Terminal:
+    """Terminal logic"""
 
     def __init__(self, configuration):
-        self.configuration = configuration
-        path = shutil.which(configuration.terminal);
+        self._configuration = configuration
+        path = shutil.which(configuration.get_terminal())
 
         if not path:
-            raise RuntimeError('Nautiterm: Unable to find configured terminal: %s' % configuration.terminal)
+            raise RuntimeError(
+                f'Nautiterm: Unable to find configured terminal: {configuration.get_terminal()}')
 
         while os.path.islink(path):
             path = shutil.which(os.readlink(path))
 
-        self.path = path
-        self.name = os.path.basename(path)
+        self._path = path
+        self._name = os.path.basename(path)
 
     def open(self, file):
+        """Launches the terminal"""
         open_path = file.get_location().get_path()
 
-        if 'gnome-terminal' in self.name or 'terminator' in self.name:
-            subprocess.Popen([self.path, '--working-directory={p}'.format(p=open_path)])
+        if 'gnome-terminal' in self._name or 'terminator' in self._name:
+            subprocess.run(
+                [self._path, f'--working-directory={open_path}'], check=False)
         else:
             os.chdir(open_path)
-            subprocess.Popen([self.path])
+            subprocess.run([self._path], check=False)
+
+    def get_name(self):
+        '''Returns terminal executable name without full path'''
+        return self._name
 
 
 class OpenTerminalExtension(Nautilus.MenuProvider, GObject.GObject):
+    """Class implements Mautiterm module """
 
     def __init__(self):
-        self.configuration = Configuration()
-        self.terminal = Terminal(self.configuration)
+        self._configuration = Configuration()
+        self._terminal = Terminal(self._configuration)
 
-    def menu_activate_cb(self, menu, file):
-        self.terminal.open(file)
+    def _menu_activate_cb(self, _, file):
+        self._terminal.open(file)
 
-    def menu_background_activate_cb(self, menu, file):
-        self.terminal.open(file)
+    def _menu_background_activate_cb(self, _, file):
+        self._terminal.open(file)
 
-    def get_file_items(self, window, files):
+    def get_file_items(self, _, files):  # pylint: disable=arguments-differ
+        '''Adds menu item for files and directories'''
+
         if len(files) != 1:
-            return
+            return None
 
         file = files[0]
         if not file.is_directory() or file.get_uri_scheme() != 'file':
-            return
+            return None
 
         label = 'Open Terminal'
-        if self.configuration.display_name:
-            label += ' (%s)' % self.terminal.name
+        if self._configuration.is_display_name():
+            label += f' ({self._terminal.get_name()})'
 
-        item = Nautilus.MenuItem(name='NautilusPython::openterminal_file_item',
-                                 label=label,
-                                 tip='Open Terminal In %s' % file.get_name())
-        item.connect('activate', self.menu_activate_cb, file)
-        return item,
+        item = Nautilus.MenuItem(
+            name='NautilusPython::openterminal_file_item',
+            label=label,
+            tip=f'Open Terminal In {file.get_name()}')
+        item.connect('activate', self._menu_activate_cb, file)
+        return (item,)
 
-    def get_background_items(self, window, file):
+    def get_background_items(self, _, file): # pylint: disable=arguments-differ
+        '''Adds menu item for current directory'''
+
         label = 'Open Terminal'
-        if self.configuration.display_name:
-            label += ' (%s)' % self.terminal.name
+        if self._configuration.is_display_name():
+            label += f' ({self._terminal.get_name()})'
 
-        item = Nautilus.MenuItem(name='NautilusPython::openterminal_file_item2',
-                                 label=label,
-                                 tip='Open Terminal In %s' % file.get_name())
-        item.connect('activate', self.menu_background_activate_cb, file)
-        return item,
+        item = Nautilus.MenuItem(
+            name='NautilusPython::openterminal_file_item2',
+            label=label,
+            tip=f'Open Terminal In {file.get_name()}')
+        item.connect('activate', self._menu_background_activate_cb, file)
+
+        return (item,)

--- a/src/nautiterm/open_terminal.py
+++ b/src/nautiterm/open_terminal.py
@@ -19,13 +19,13 @@ import subprocess
 import sys
 import yaml  # for loading configuration
 import gi
+from pathlib import Path
 
 gi.require_version('Nautilus', '3.0')
 from gi.repository import Nautilus, GObject, Gio
 
 CONFIG_FILE_NAME = 'nautiterm.yml'
-CONFIG_FILE_DIR = os.environ.get('XDG_CONFIG_HOME',
-                                 os.path.join(os.environ['HOME'], '.config'))
+CONFIG_FILE_DIR = os.environ.get('XDG_CONFIG_HOME', os.path.join(os.environ['HOME'], '.config'))
 CONFIG_FILE_PATH = os.path.join(CONFIG_FILE_DIR, CONFIG_FILE_NAME)
 DEFAULT_TERMINAL_EXEC = 'gnome-terminal'
 
@@ -35,15 +35,29 @@ print("Starting Nautiterm")
 class OpenTerminalExtension(Nautilus.MenuProvider, GObject.GObject):
 
     def __init__(self):
-        pass
+        try:
+            with open(CONFIG_FILE_PATH) as conffile:
+                config = yaml.load(conffile, yaml.SafeLoader)
+            self.terminal = config.get('terminal', None)
+            self.displayName = config.get('display-name', True)
+            if not self.terminal:
+                self.terminal = DEFAULT_TERMINAL_EXEC
+        except yaml.YAMLError:
+            print("Nautiterm: invalid configuration file at {path}, falling back" + " to {d}".format(path=CONFIG_FILE_PATH, d=DEFAULT_TERMINAL_EXEC), file=sys.stderr)
+        except IOError as ioe:
+            # catch-all for permission errors and file not founds to be compatible
+            # with Python 2 which doesn't have FileNotFoundError or PermissionError
+            pass
 
     def _open_terminal(self, file):
         gvfs = Gio.Vfs.get_default()
         open_path = gvfs.get_file_for_uri(file.get_uri()).get_path()
 
         exc = self._get_terminal_exec()
-        if 'gnome-terminal' in exc or 'terminator' in exc:
-            subprocess.Popen([self._get_terminal_exec(), '--working-directory={p}'.format(p=open_path)])
+        excName = exc.name
+        exc = exc.as_posix()
+        if 'gnome-terminal' in excName or 'terminator' in excName:
+            subprocess.Popen([exc, '--working-directory={p}'.format(p=open_path)])
         else:
             os.chdir(open_path)
             subprocess.Popen([exc])
@@ -54,25 +68,18 @@ class OpenTerminalExtension(Nautilus.MenuProvider, GObject.GObject):
         configuration, or gnome-terminal if nothing else has been specified.
         """
 
-        terminal = None
+        purePath = Path(self.terminal)
 
-        try:
-            with open(CONFIG_FILE_PATH) as conffile:
-                config = yaml.load(conffile, yaml.SafeLoader)
-            terminal = config.get('terminal', None)
-        except yaml.YAMLError:
-            print("Nautiterm: invalid configuration file at {path}, falling back" +
-                  " to {d}".format(path=CONFIG_FILE_PATH, d=DEFAULT_TERMINAL_EXEC),
-                  file=sys.stderr)
-        except IOError as ioe:
-            # catch-all for permission errors and file not founds to be compatible
-            # with Python 2 which doesn't have FileNotFoundError or PermissionError
-            pass
+        if not(purePath.is_absolute()):
+            envPath = os.environ['PATH'].split(':')
+            envPath.insert(0, Path.cwd())
+            for directory in envPath:
+                testPath = directory / purePath
+                if testPath.exists():
+                    purePath = testPath
+                    break
 
-        if not terminal:
-            terminal = DEFAULT_TERMINAL_EXEC
-
-        return terminal
+        return purePath.resolve();
 
     def menu_activate_cb(self, menu, file):
         self._open_terminal(file)
@@ -88,15 +95,15 @@ class OpenTerminalExtension(Nautilus.MenuProvider, GObject.GObject):
         if not file.is_directory() or file.get_uri_scheme() != 'file':
             return
 
-        item = Nautilus.MenuItem(name='NautilusPython::openterminal_file_item',
-                                 label='Open Terminal (%s)' % self._get_terminal_exec(),
-                                 tip='Open Terminal In %s' % file.get_name())
+        item = Nautilus.MenuItem(name = 'NautilusPython::openterminal_file_item',
+                                 label = 'Open Terminal (%s)' % self._get_terminal_exec().name if self.displayName else 'Open Terminal',
+                                 tip = 'Open Terminal In %s' % file.get_name())
         item.connect('activate', self.menu_activate_cb, file)
         return item,
 
     def get_background_items(self, window, file):
-        item = Nautilus.MenuItem(name='NautilusPython::openterminal_file_item2',
-                                 label='Open Terminal (%s)' % self._get_terminal_exec(),
-                                 tip='Open Terminal In %s' % file.get_name())
+        item = Nautilus.MenuItem(name = 'NautilusPython::openterminal_file_item2',
+                                 label = 'Open Terminal (%s)' % self._get_terminal_exec().name if self.displayName else 'Open Terminal',
+                                 tip = 'Open Terminal In %s' % file.get_name())
         item.connect('activate', self.menu_background_activate_cb, file)
         return item,

--- a/src/nautiterm/open_terminal.py
+++ b/src/nautiterm/open_terminal.py
@@ -85,7 +85,7 @@ class Terminal:
             subprocess.Popen([self.path, '--working-directory={p}'.format(p=open_path)])
         else:
             os.chdir(open_path)
-            subprocess.Popen([exc])
+            subprocess.Popen([self.path])
 
 
 class OpenTerminalExtension(Nautilus.MenuProvider, GObject.GObject):

--- a/src/nautiterm/open_terminal.py
+++ b/src/nautiterm/open_terminal.py
@@ -36,29 +36,9 @@ DEFAULT_TERMINAL_EXEC = 'gnome-terminal'
 
 print("Starting Nautiterm")
 
-
-class OpenTerminalExtension(Nautilus.MenuProvider, GObject.GObject):
+class Configuration:
 
     def __init__(self):
-        pass
-
-    def _open_terminal(self, file):
-        gvfs = Gio.Vfs.get_default()
-        open_path = gvfs.get_file_for_uri(file.get_uri()).get_path()
-
-        exc = self._get_terminal_exec()
-        if 'gnome-terminal' in exc or 'terminator' in exc:
-            subprocess.Popen([self._get_terminal_exec(), '--working-directory={p}'.format(p=open_path)])
-        else:
-            os.chdir(open_path)
-            subprocess.Popen([exc])
-
-    def _get_terminal_exec(self):
-        """
-        Returns the executable name of a terminal emulator to launch based on user
-        configuration, or gnome-terminal if nothing else has been specified.
-        """
-
         terminal = None
 
         try:
@@ -76,6 +56,33 @@ class OpenTerminalExtension(Nautilus.MenuProvider, GObject.GObject):
 
         if not terminal:
             terminal = DEFAULT_TERMINAL_EXEC
+
+        """
+        Contains the executable name of a terminal emulator to launch based on user
+        configuration, or gnome-terminal if nothing else has been specified.
+        """
+        self.terminal = terminal
+
+
+class OpenTerminalExtension(Nautilus.MenuProvider, GObject.GObject):
+
+    def __init__(self):
+        self.configuration = Configuration()
+
+    def _open_terminal(self, file):
+        gvfs = Gio.Vfs.get_default()
+        open_path = gvfs.get_file_for_uri(file.get_uri()).get_path()
+
+        exc = self._get_terminal_exec()
+        if 'gnome-terminal' in exc or 'terminator' in exc:
+            subprocess.Popen([self._get_terminal_exec(), '--working-directory={p}'.format(p=open_path)])
+        else:
+            os.chdir(open_path)
+            subprocess.Popen([exc])
+
+    def _get_terminal_exec(self):
+
+        terminal = self.configuration.terminal
 
         terminal = shutil.which(terminal);
 
@@ -110,3 +117,5 @@ class OpenTerminalExtension(Nautilus.MenuProvider, GObject.GObject):
                                  tip='Open Terminal In %s' % file.get_name())
         item.connect('activate', self.menu_background_activate_cb, file)
         return item,
+
+


### PR DESCRIPTION
Hi. This commit allows to set the terminal in the configuration to something like `x-terminal-emulator`, but the terminal name will be taken from the actual executable, pointed to by the symlink. I also added the `display-name` config option which can hide the terminal name from the context menu.